### PR TITLE
Provide instructions for node 0.10 use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ To use spriting, install eyeglass and eyeglass-spriting:
 
 Register your sprite source images as [eyeglass assets](https://github.com/sass-eyeglass/eyeglass#working-with-assets), and `@import 'spriting'` in your sass files.
 
-Please also note this requires use of `node` version `0.12` or newer. (Check with `node -v`.)
+Please also note this requires either:
+
+  - `node` version `0.12` or newer (check with `node -v`), or
+  - the [Babel polyfill] for node `0.12` compatibility (`npm install --save-dev babel` and add `require("babel/polyfill");` to the top of your build file (like `Brocfile.js` or `ember-cli-build.js`).
+
+[Babel polyfill]: http://babeljs.io/docs/usage/polyfill/ "Babel.js polyfill information"
 
 # Quick Start
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Register your sprite source images as [eyeglass assets](https://github.com/sass-
 Please also note this requires either:
 
   - `node` version `0.12` or newer (check with `node -v`), or
-  - the [Babel polyfill] for node `0.10` compatibility (`npm install --save-dev babel` and add `require("babel/polyfill");` to the top of your build file (like `Brocfile.js` or `ember-cli-build.js`).
+  - the [Babel polyfill] for node `0.10` compatibility (`npm install --save-dev babel-core` and add `require("babel-core/polyfill");` to the top of your build file (like `Brocfile.js` or `ember-cli-build.js`).
 
 [Babel polyfill]: http://babeljs.io/docs/usage/polyfill/ "Babel.js polyfill information"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Register your sprite source images as [eyeglass assets](https://github.com/sass-
 Please also note this requires either:
 
   - `node` version `0.12` or newer (check with `node -v`), or
-  - the [Babel polyfill] for node `0.12` compatibility (`npm install --save-dev babel` and add `require("babel/polyfill");` to the top of your build file (like `Brocfile.js` or `ember-cli-build.js`).
+  - the [Babel polyfill] for node `0.10` compatibility (`npm install --save-dev babel` and add `require("babel/polyfill");` to the top of your build file (like `Brocfile.js` or `ember-cli-build.js`).
 
 [Babel polyfill]: http://babeljs.io/docs/usage/polyfill/ "Babel.js polyfill information"
 


### PR DESCRIPTION
Good news! node 0.12 isn’t a hard requirement if you use an ES6 polyfill for Symbol & Map. This commit should provide everything a prospective user needs to use eyeglass-spriting with node 0.10.
